### PR TITLE
fix(ui): match install button size to launch button

### DIFF
--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -277,7 +277,7 @@ input[type="range"]::-moz-range-thumb{width:13px;height:13px;border-radius:50%;b
 
 /* ── Install Area ── */
 .install-text{text-align:center;font-size:12px;color:var(--text-dim);margin-bottom:10px}
-.install-btn{font-family:var(--font-sans);font-size:13px;font-weight:600;letter-spacing:.08em;color:var(--bg-deep);background:var(--accent);border:none;border-radius:var(--r-md);padding:11px 40px;cursor:pointer;transition:transform .1s,opacity .15s}
+.install-btn{font-family:var(--font-sans);font-size:15px;font-weight:700;letter-spacing:.14em;color:var(--bg-deep);background:var(--accent);border:none;border-radius:var(--r-md);padding:13px 52px;cursor:pointer;transition:transform .1s,opacity .15s}
 .install-btn:hover{transform:translateY(-1px);opacity:.9}
 .install-btn:active{transform:translateY(1px)}
 .install-btn:disabled{opacity:.5;cursor:default;transform:none}


### PR DESCRIPTION
## Summary
- Aligned `.install-btn` styling (font-size, font-weight, letter-spacing, padding) to match `.launch-btn` so the button no longer appears smaller when showing text like "Install incomplete"

## Test plan
- [x] Verify install button renders at the same size as the launch button
- [x] Confirm button size remains consistent regardless of label text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the install button appearance with increased font size, font weight, letter spacing, and padding for better prominence and user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->