### PR TITLE
fix(ui): prevent settings nav from stretching at low resolutions

### DIFF
--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -202,8 +202,8 @@ input[type="range"]::-moz-range-thumb{width:13px;height:13px;border-radius:50%;b
 .sidebar-settings-panel{padding:10px 10px 12px}
 .sidebar-settings-head{padding:2px 2px 12px;border-bottom:1px solid var(--border);margin-bottom:10px}
 .sidebar-settings-title{font-family:var(--font-sans);font-size:18px;line-height:1;margin:6px 0 4px;letter-spacing:-.03em}
-.settings-nav{flex:1;min-height:0;overflow-y:auto}
-.sidebar-settings-actions{display:flex;gap:8px;flex-wrap:wrap;flex-shrink:0;padding-top:10px}
+.settings-nav{min-height:0;overflow-y:auto}
+.sidebar-settings-actions{display:flex;gap:8px;flex-wrap:wrap;flex-shrink:0;padding-top:10px;margin-top:auto}
 
 /* ══════════════ CENTER PANEL ══════════════ */
 


### PR DESCRIPTION
## Summary
- Removed `flex:1` from `.settings-nav` so the nav container no longer stretches to fill all available sidebar space, which caused buttons to appear ~94px tall at low resolutions
- Added `margin-top:auto` to `.sidebar-settings-actions` to keep the Back/Save buttons pinned at the bottom of the sidebar without relying on the nav's flex growth

## Test plan
- [ ] Open the Settings tab at a low viewport resolution (~720p) and verify nav buttons are ~30px tall, not stretched
- [ ] Verify the Back/Save action buttons remain at the bottom of the sidebar
- [ ] Check that at larger resolutions the sidebar still looks correct and scrolls if many nav items are present