### PR TITLE
fix(ui): make instance status dot reactive to version changes

### DIFF
--- a/frontend/src/components/InstanceItem.tsx
+++ b/frontend/src/components/InstanceItem.tsx
@@ -2,7 +2,7 @@ import type { JSX } from 'preact';
 import { useComputed } from '@preact/signals';
 import type { Instance, Version } from '../types';
 import {
-  selectedInstanceId, runningSessions, installState, installQueue, versions,
+  selectedInstanceId, runningSessions, installState, installQueue, versions, versionMap,
 } from '../store';
 import { selectInstance } from '../actions';
 import { parseVersionDisplay } from '../utils';
@@ -151,9 +151,11 @@ export function InstanceItem({ instance, version, index, onContextMenu }: Instan
   const isRunning = useComputed(() => !!runningSessions.value[instance.id]);
   const isSelected = useComputed(() => selectedInstanceId.value === instance.id);
 
-  const dotClass = useComputed(() =>
-    isRunning.value ? 'running' : version?.launchable ? 'ok' : 'missing'
-  );
+  const dotClass = useComputed(() => {
+    if (isRunning.value) return 'running';
+    const v = versionMap.value.get(instance.version_id);
+    return v?.launchable ? 'ok' : 'missing';
+  });
 
   const badgeClass = useComputed(() => {
     const p = pd.value;


### PR DESCRIPTION
## Summary
- The `dotClass` computed in `InstanceItem` was reading `version?.launchable` from a plain prop, which is not tracked by `@preact/signals`. Changes to a version's launchable status (e.g., after install completes) did not trigger re-computation of the status dot.
- Fixed by reading from the reactive `versionMap` signal inside the computed, so the dot now updates automatically when version state changes.

## Test plan
- [ ] Install a version while an instance using it is visible; verify the status dot transitions from red/missing to green/ok without needing to re-select the instance.
- [ ] Launch an instance and confirm the dot still shows the running state correctly.