### PR TITLE
fix(ui): skip redundant version hints in snapshot display

### DIFF
--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -149,7 +149,7 @@ function parseModded(id: string, base: string): VersionDisplay {
 function parseSnapshot(id: string, version: any, versions: any[]): VersionDisplay {
   // pre-release / release candidate: 1.20.5-pre1, 1.20.5-rc1
   const m = id.match(/^(\d+\.\d+(?:\.\d+)?)-(?:pre|rc)\d+$/);
-  if (m) return { name: id, hint: `\u2192 ${m[1]}` };
+  if (m) return { name: id, hint: null };
   // weekly snapshot: find nearest release by time
   if (versions?.length && version?.release_time) {
     const t = version.release_time as string;
@@ -159,7 +159,7 @@ function parseSnapshot(id: string, version: any, versions: any[]): VersionDispla
     for (const r of rel) { if (r.release_time >= t) { nearest = r; break; } }
     // if none after, use last release before
     if (!nearest) { for (let i = rel.length - 1; i >= 0; i--) { if (rel[i].release_time <= t) { nearest = rel[i]; break; } } }
-    if (nearest) return { name: id, hint: `~ ${nearest.id}` };
+    if (nearest && !id.includes(nearest.id)) return { name: id, hint: `~ ${nearest.id}` };
   }
   return { name: id, hint: null };
 }


### PR DESCRIPTION
## Summary
- Remove always-redundant arrow hints for pre-release/RC versions (e.g. "1.21.6-pre1" no longer shows "→ 1.21.6")
- Add `!id.includes(nearest.id)` guard for weekly snapshots so hints are only shown when the version ID doesn't already contain the referenced release

## Test plan
- [ ] Verify pre-release versions like "1.21.6-pre1" and "1.21.6-rc1" no longer display a hint
- [ ] Verify weekly snapshots like "25w14a" still display their approximate release hint
- [ ] Verify edge cases where a weekly snapshot ID happens to contain a release version string also suppress the hint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version snapshot hint accuracy for pre-release and weekly snapshot versions. Snapshot hints are now displayed more selectively to avoid redundant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->