### PR TITLE
fix(ui): crop Fabric modloader icon for better recognition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
           cp frontend/static/logo.png dist/appimage/AppDir/usr/share/icons/hicolor/256x256/apps/croopor.png
           ln -sf usr/share/applications/croopor.desktop dist/appimage/AppDir/croopor.desktop
           ln -sf usr/share/icons/hicolor/256x256/apps/croopor.png dist/appimage/AppDir/.DirIcon
+          ln -sf usr/share/icons/hicolor/256x256/apps/croopor.png dist/appimage/AppDir/croopor.png
           cat > dist/appimage/AppDir/AppRun <<'EOF'
           #!/bin/sh
           HERE="$(dirname "$(readlink -f "$0")")"

--- a/frontend/src/components/InstanceItem.tsx
+++ b/frontend/src/components/InstanceItem.tsx
@@ -14,7 +14,7 @@ function LoaderIcon({ loader }: { loader: string }): JSX.Element | null {
     case 'fabric':
       // Fabric pixel-art knot (cropped to content)
       return (
-        <svg width="12" height="12" viewBox="2 2 13 13" shape-rendering="crispEdges">
+        <svg width="10" height="10" viewBox="2 2 13 13" shape-rendering="crispEdges">
           <rect x="8" y="2" width="1" height="1" fill="#38342a" />
           <rect x="9" y="2" width="1" height="1" fill="#dbd0b4" />
           <rect x="10" y="2" width="1" height="1" fill="#38342a" />


### PR DESCRIPTION
## Summary
[unfinished]

## Pending work
- [x] find a better solution to this issue than bumping the wxh (which btw doesn't even improve it becuase of the nature of the logo)
- [x] revert the shitty solution i just comitted

## Test plan
- [x] Verify the Fabric badge icon is visually recognizable in the instance list
- [x] Verify Quilt, Forge, and NeoForge icons are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the fabric loader icon appearance for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->