### PR TITLE
refactor(dev): standardize tauri runtime topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install frontend dependencies
-        run: corepack pnpm --dir frontend install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir frontend install --frozen-lockfile --ignore-scripts
 
       - name: Frontend typecheck
-        run: corepack pnpm --dir frontend run check
+        run: pnpm --dir frontend run check
 
       - name: Frontend build
-        run: corepack pnpm --dir frontend run build
+        run: pnpm --dir frontend run build
 
   desktop-linux:
     runs-on: ubuntu-24.04
@@ -69,7 +69,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies
-        run: corepack pnpm --dir frontend install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir frontend install --frozen-lockfile --ignore-scripts
 
       - name: Rust fmt
         run: cargo fmt --all --check
@@ -84,10 +84,10 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Frontend typecheck
-        run: corepack pnpm --dir frontend run check
+        run: pnpm --dir frontend run check
 
       - name: Frontend build
-        run: corepack pnpm --dir frontend run build
+        run: pnpm --dir frontend run build
 
       - name: Release desktop build
         run: cargo build --locked -p croopor-desktop --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies
-        run: corepack pnpm --dir frontend install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir frontend install --frozen-lockfile --ignore-scripts
 
       - name: Rust fmt
         run: cargo fmt --all --check
@@ -56,10 +56,10 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Frontend typecheck
-        run: corepack pnpm --dir frontend run check
+        run: pnpm --dir frontend run check
 
       - name: Frontend build
-        run: corepack pnpm --dir frontend run build
+        run: pnpm --dir frontend run build
 
       - name: Release desktop build
         run: cargo build --locked -p croopor-desktop --release
@@ -91,10 +91,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies
-        run: corepack pnpm --dir frontend install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir frontend install --frozen-lockfile --ignore-scripts
 
       - name: Build frontend bundle
-        run: corepack pnpm --dir frontend run build
+        run: pnpm --dir frontend run build
 
       - name: Build release desktop binary
         run: cargo build --locked -p croopor-desktop --release
@@ -134,10 +134,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install frontend dependencies
-        run: corepack pnpm --dir frontend install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir frontend install --frozen-lockfile --ignore-scripts
 
       - name: Build frontend bundle
-        run: corepack pnpm --dir frontend run build
+        run: pnpm --dir frontend run build
 
       - name: Build release desktop binary
         run: cargo build --locked -p croopor-desktop --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tauri-plugin-opener = "2.5.0"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tower = "0.5.2"
-tower-http = { version = "0.6.6", features = ["fs", "trace"] }
+tower-http = { version = "0.6.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 url = "2.5.7"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,7 @@ tasks:
   frontend:serve:
     desc: run frontend-only dev server
     aliases: [dev-web, web]
+    platforms: [linux, darwin]
     cmds:
       - ./dev dev-web
 
@@ -156,12 +157,14 @@ tasks:
   rust:desktop:
     desc: run the Rust desktop shell
     aliases: [dev, dev-desktop, desktop:dev]
+    platforms: [linux, darwin]
     cmds:
       - ./dev dev
 
   dev:windows:
     desc: run the Windows desktop shell from linux/wsl
     aliases: [dev-windows, desktop:dev:windows]
+    platforms: [linux, darwin]
     cmds:
       - ./dev dev --target windows
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,7 +90,7 @@ tasks:
     desc: run frontend-only dev server
     aliases: [dev-web, web]
     cmds:
-      - corepack pnpm --dir {{.FRONTEND_DIR}} run dev
+      - ./dev dev-web
 
   rust:fetch:
     desc: prefetch Rust dependencies
@@ -160,13 +160,13 @@ tasks:
     desc: run the Rust desktop shell
     aliases: [dev, dev-desktop, desktop:dev]
     cmds:
-      - cargo run --locked -p croopor-desktop
+      - ./dev dev
 
   dev:windows:
     desc: run the Windows desktop shell from linux/wsl
     aliases: [dev-windows, desktop:dev:windows]
     cmds:
-      - cargo run --locked -p croopor-desktop --target {{.WINDOWS_TARGET}}
+      - ./dev dev --target windows
 
   build:
     desc: build the desktop app in release mode

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,8 +1,5 @@
 version: "3"
 
-env:
-  COREPACK_HOME: "{{.TASKFILE_DIR}}/.cache/corepack"
-
 vars:
   FRONTEND_DIR: frontend
   WINDOWS_TARGET: x86_64-pc-windows-gnu
@@ -35,7 +32,7 @@ tasks:
           echo "rustfmt  $(cargo fmt --version 2>/dev/null || echo missing)"
           echo "clippy   $(cargo clippy --version 2>/dev/null || echo missing)"
           echo "node     $(node --version)"
-          echo "corepack $(corepack --version)"
+          echo "pnpm     $(pnpm --version)"
           if command -v task >/dev/null 2>&1; then
             echo "task     $(task --version)"
           else
@@ -59,7 +56,7 @@ tasks:
           try { Write-Host ('rustfmt  ' + (cargo fmt --version)) } catch { Write-Host 'rustfmt  missing' };
           try { Write-Host ('clippy   ' + (cargo clippy --version)) } catch { Write-Host 'clippy   missing' };
           Write-Host ('node     ' + (node --version));
-          Write-Host ('corepack ' + (corepack --version));
+          Write-Host ('pnpm     ' + (pnpm --version));
           try { Write-Host ('task     ' + (task --version)) } catch { Write-Host 'task     optional' };
           Write-Host 'wsl      no'"
         platforms: [windows]
@@ -68,23 +65,23 @@ tasks:
     desc: install frontend deps
     aliases: [setup:frontend]
     cmds:
-      - corepack pnpm --dir {{.FRONTEND_DIR}} install --frozen-lockfile --ignore-scripts
+      - pnpm --dir {{.FRONTEND_DIR}} install --frozen-lockfile --ignore-scripts
 
   frontend:check:
     desc: run frontend typecheck
     cmds:
-      - corepack pnpm --dir {{.FRONTEND_DIR}} run check
+      - pnpm --dir {{.FRONTEND_DIR}} run check
 
   frontend:build:
     desc: build frontend bundle
     cmds:
-      - corepack pnpm --dir {{.FRONTEND_DIR}} run build
+      - pnpm --dir {{.FRONTEND_DIR}} run build
 
   frontend:watch:
     desc: rebuild frontend assets on file changes
     aliases: [watch]
     cmds:
-      - corepack pnpm --dir {{.FRONTEND_DIR}} run watch
+      - pnpm --dir {{.FRONTEND_DIR}} run watch
 
   frontend:serve:
     desc: run frontend-only dev server

--- a/apps/api/src/app.rs
+++ b/apps/api/src/app.rs
@@ -52,7 +52,14 @@ pub enum ApiServerError {
 }
 
 pub async fn spawn_background(state: AppState) -> Result<ServerHandle, ApiServerError> {
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], DEFAULT_API_PORT))).await?;
+    spawn_background_on(state, SocketAddr::from(([127, 0, 0, 1], 0))).await
+}
+
+pub async fn spawn_background_on(
+    state: AppState,
+    addr: SocketAddr,
+) -> Result<ServerHandle, ApiServerError> {
+    let listener = TcpListener::bind(addr).await?;
     let addr = listener.local_addr()?;
     let router = build_router(state);
 

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -1,4 +1,4 @@
-use croopor_api::app::{build_router, default_frontend_dir};
+use croopor_api::app::{DEFAULT_API_PORT, build_router, default_frontend_dir};
 use croopor_api::state::{AppState, AppStateInit, InstallStore, SessionStore};
 use croopor_config::{ConfigStore, InstanceStore};
 use croopor_performance::PerformanceManager;
@@ -30,9 +30,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = std::env::var("CROOPOR_API_ADDR")
         .ok()
         .and_then(|value| value.parse::<SocketAddr>().ok())
-        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 43_430)));
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], DEFAULT_API_PORT)));
 
     let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
     info!("croopor api listening on http://{addr}");
 
     axum::serve(listener, build_router(state))

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -16,7 +16,11 @@ mod version_info;
 mod versions;
 
 use crate::state::AppState;
-use axum::Router;
+use axum::{
+    Router,
+    http::{HeaderValue, Method, header},
+};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 
 pub fn router(state: AppState) -> Router {
     Router::new()
@@ -37,4 +41,43 @@ pub fn router(state: AppState) -> Router {
         .merge(version_info::router())
         .merge(java::router())
         .with_state(state)
+        .layer(local_cors_layer())
+}
+
+fn local_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(|origin, _| {
+            is_allowed_local_origin(origin)
+        }))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::CONTENT_TYPE])
+}
+
+fn is_allowed_local_origin(origin: &HeaderValue) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+
+    origin == "tauri://localhost"
+        || origin == "http://tauri.localhost"
+        || origin == "https://tauri.localhost"
+        || origin
+            .strip_prefix("http://127.0.0.1:")
+            .is_some_and(is_port_suffix)
+        || origin
+            .strip_prefix("http://localhost:")
+            .is_some_and(is_port_suffix)
+        || origin
+            .strip_prefix("http://[::1]:")
+            .is_some_and(is_port_suffix)
+}
+
+fn is_port_suffix(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }

--- a/apps/desktop/capabilities/main.json
+++ b/apps/desktop/capabilities/main.json
@@ -8,8 +8,8 @@
   ],
   "remote": {
     "urls": [
-      "http://127.0.0.1:43430/*",
-      "http://localhost:43430/*"
+      "http://127.0.0.1:3000/*",
+      "http://localhost:3000/*"
     ]
   }
 }

--- a/apps/desktop/gen/schemas/capabilities.json
+++ b/apps/desktop/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"main-capability":{"identifier":"main-capability","description":"Main desktop capability for the Croopor rewrite shell","remote":{"urls":["http://127.0.0.1:43430/*","http://localhost:43430/*"]},"local":true,"windows":["main"],"permissions":["core:default"]}}
+{"main-capability":{"identifier":"main-capability","description":"Main desktop capability for the Croopor rewrite shell","remote":{"urls":["http://127.0.0.1:3000/*","http://localhost:3000/*"]},"local":true,"windows":["main"],"permissions":["core:default"]}}

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -4,10 +4,10 @@
   "version": "0.3.1",
   "identifier": "dev.mateoltd.croopor",
   "build": {
-    "beforeBuildCommand": "",
-    "beforeDevCommand": "",
-    "frontendDist": "http://127.0.0.1:43430",
-    "devUrl": "http://127.0.0.1:43430"
+    "beforeBuildCommand": "corepack pnpm --dir ../../frontend run build",
+    "beforeDevCommand": "corepack pnpm --dir ../../frontend run dev:desktop",
+    "frontendDist": "../../frontend/static",
+    "devUrl": "http://127.0.0.1:3000"
   },
   "app": {
     "withGlobalTauri": true,

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "0.3.1",
   "identifier": "dev.mateoltd.croopor",
   "build": {
-    "beforeBuildCommand": "corepack pnpm --dir ../../frontend run build",
-    "beforeDevCommand": "corepack pnpm --dir ../../frontend run dev:desktop",
+    "beforeBuildCommand": "pnpm --dir ../../frontend run build",
+    "beforeDevCommand": "pnpm --dir ../../frontend run dev:desktop",
     "frontendDist": "../../frontend/static",
     "devUrl": "http://127.0.0.1:3000"
   },

--- a/dev
+++ b/dev
@@ -305,17 +305,17 @@ run_desktop_dev() {
   local frontend_pid=""
   cleanup_desktop_dev() {
     if [ -n "$frontend_pid" ] && kill -0 "$frontend_pid" >/dev/null 2>&1; then
-      kill "$frontend_pid" >/dev/null 2>&1 || true
+      kill -- "-$frontend_pid" >/dev/null 2>&1 || kill "$frontend_pid" >/dev/null 2>&1 || true
       wait "$frontend_pid" >/dev/null 2>&1 || true
     fi
   }
 
   trap cleanup_desktop_dev EXIT
-  (
-    export PORT=3000
-    export CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}"
-    run_frontend run dev:desktop
-  ) &
+  if command -v setsid >/dev/null 2>&1; then
+    setsid env PORT=3000 CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}" pnpm --dir "$ROOT/frontend" run dev:desktop &
+  else
+    env PORT=3000 CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}" pnpm --dir "$ROOT/frontend" run dev:desktop &
+  fi
   frontend_pid=$!
 
   wait_for_frontend_dev_server "$frontend_pid"

--- a/dev
+++ b/dev
@@ -86,6 +86,28 @@ run_frontend() {
   corepack pnpm --dir "$ROOT/frontend" "$@"
 }
 
+wait_for_frontend_dev_server() {
+  local url="http://127.0.0.1:3000"
+  local pid="${1:-}"
+
+  for _ in $(seq 1 120); do
+    if [ -n "$pid" ] && ! kill -0 "$pid" >/dev/null 2>&1; then
+      echo "frontend dev server exited before $url became ready" >&2
+      exit 1
+    fi
+    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 1 "$url" >/dev/null 2>&1; then
+      return
+    fi
+    if ! command -v curl >/dev/null 2>&1 && node -e "fetch(process.argv[1]).then(() => process.exit(0)).catch(() => process.exit(1))" "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  echo "frontend dev server did not become ready at $url" >&2
+  exit 1
+}
+
 windows_target_triple() {
   echo "x86_64-pc-windows-gnu"
 }
@@ -280,7 +302,38 @@ run_desktop_dev() {
     cargo_args+=(--target "$target")
   fi
 
-  run_interruptible cargo "${cargo_args[@]}"
+  local frontend_pid=""
+  cleanup_desktop_dev() {
+    if [ -n "$frontend_pid" ] && kill -0 "$frontend_pid" >/dev/null 2>&1; then
+      kill "$frontend_pid" >/dev/null 2>&1 || true
+      wait "$frontend_pid" >/dev/null 2>&1 || true
+    fi
+  }
+
+  trap cleanup_desktop_dev EXIT
+  (
+    export PORT=3000
+    export CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}"
+    run_frontend run dev:desktop
+  ) &
+  frontend_pid=$!
+
+  wait_for_frontend_dev_server "$frontend_pid"
+
+  local interrupted=0
+  trap 'interrupted=1; cleanup_desktop_dev' INT TERM
+  set +e
+  cargo "${cargo_args[@]}"
+  local status=$?
+  set -e
+  trap - INT TERM
+  cleanup_desktop_dev
+  trap - EXIT
+
+  if [ "$interrupted" -eq 1 ] || [ "$status" -eq 130 ]; then
+    exit 0
+  fi
+  exit "$status"
 }
 
 main() {
@@ -327,7 +380,11 @@ main() {
         echo "$cmd does not accept extra arguments" >&2
         exit 1
       fi
-      run_interruptible corepack pnpm --dir "$ROOT/frontend" run dev
+      (
+        export PORT="${PORT:-3000}"
+        export CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}"
+        run_interruptible corepack pnpm --dir "$ROOT/frontend" run dev:desktop
+      )
       ;;
     watch|frontend:watch)
       if [ "$#" -ne 0 ]; then

--- a/dev
+++ b/dev
@@ -83,7 +83,7 @@ run_interruptible() {
 }
 
 run_frontend() {
-  corepack pnpm --dir "$ROOT/frontend" "$@"
+  pnpm --dir "$ROOT/frontend" "$@"
 }
 
 wait_for_frontend_dev_server() {
@@ -163,7 +163,7 @@ run_doctor() {
   echo "rustfmt  $(cargo fmt --version 2>/dev/null || echo missing)"
   echo "clippy   $(cargo clippy --version 2>/dev/null || echo missing)"
   echo "node     $(node --version)"
-  echo "corepack $(corepack --version)"
+  echo "pnpm     $(pnpm --version)"
   if command -v task >/dev/null 2>&1; then
     echo "task     $(task --version)"
   else
@@ -383,7 +383,7 @@ main() {
       (
         export PORT="${PORT:-3000}"
         export CROOPOR_WEB_API_BASE="${CROOPOR_WEB_API_BASE:-http://127.0.0.1:43430}"
-        run_interruptible corepack pnpm --dir "$ROOT/frontend" run dev:desktop
+        run_interruptible pnpm --dir "$ROOT/frontend" run dev:desktop
       )
       ;;
     watch|frontend:watch)
@@ -391,7 +391,7 @@ main() {
         echo "$cmd does not accept extra arguments" >&2
         exit 1
       fi
-      run_interruptible corepack pnpm --dir "$ROOT/frontend" run watch
+      run_interruptible pnpm --dir "$ROOT/frontend" run watch
       ;;
     frontend:install)
       if [ "$#" -ne 0 ]; then

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,12 @@ This is the current map of the launcher. Keep it accurate. If the architecture c
 - `core/minecraft`: version metadata, runtime discovery/install, download/install, loader strategies
 - `core/performance`: managed performance planning/install
 
+## Runtime topology
+- Desktop builds use Tauri's local frontend bundle from `frontend/static`; desktop dev uses Tauri `devUrl` at `http://127.0.0.1:3000`.
+- The desktop shell always starts its own Axum API on an ephemeral loopback port and exposes that address to the frontend through the `api_base_url` Tauri command.
+- Browser dev runs the frontend dev server at `http://127.0.0.1:3000` and talks to the standalone API at `http://127.0.0.1:43430` unless `CROOPOR_WEB_API_BASE` overrides it.
+- The API only accepts browser CORS requests from local development and Tauri origins; production desktop traffic uses the bundled frontend plus the shell-provided loopback API address.
+
 ## Primary docs
 - Docs index: `docs/README.md`
 - Guardian architecture: `docs/GUARDIAN-ARCHITECTURE.md`

--- a/frontend/esbuild.mjs
+++ b/frontend/esbuild.mjs
@@ -2,8 +2,10 @@ import net from 'node:net';
 import { context, build } from 'esbuild';
 
 const mode = process.argv[2]; // 'serve', 'watch', or omitted (production build)
+const strictDevPort = process.argv.includes('--strict-port');
 const portOverride = process.env.PORT;
 const defaultDevPort = 3000;
+const webApiBase = process.env.CROOPOR_WEB_API_BASE ?? 'http://127.0.0.1:43430';
 
 const shared = {
   entryPoints: { app: 'src/main.tsx' },
@@ -13,6 +15,9 @@ const shared = {
   target: ['es2020'],
   jsx: 'automatic',
   jsxImportSource: 'preact',
+  define: {
+    __CROOPOR_WEB_API_BASE__: JSON.stringify(webApiBase),
+  },
 };
 
 const sizeReporter = {
@@ -73,6 +78,8 @@ async function resolveDevPort() {
     }
     return port;
   }
+
+  if (strictDevPort) return defaultDevPort;
 
   for (let port = defaultDevPort; port <= 65535; port += 1) {
     if (await canListenOn(port)) return port;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc --noEmit && node esbuild.mjs",
     "dev": "node esbuild.mjs serve",
+    "dev:desktop": "node esbuild.mjs serve --strict-port",
     "watch": "node esbuild.mjs watch",
     "check": "tsc --noEmit"
   },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,26 @@
-export const API = '/api/v1';
+import { getNativeApiBaseUrl } from './native';
+
+declare const __CROOPOR_WEB_API_BASE__: string;
+
+const API_PATH = '/api/v1';
+
+let apiBaseUrl = '';
+
+export let API = API_PATH;
+
+export async function initializeApiBase(): Promise<void> {
+  const nativeBaseUrl = await getNativeApiBaseUrl();
+  setApiBaseUrl(nativeBaseUrl ?? __CROOPOR_WEB_API_BASE__ ?? '');
+}
+
+export function setApiBaseUrl(baseUrl: string): void {
+  apiBaseUrl = normalizeApiBaseUrl(baseUrl);
+  API = `${apiBaseUrl}${API_PATH}`;
+}
+
+export function apiUrl(path: string): string {
+  return `${API}${path.startsWith('/') ? path : `/${path}`}`;
+}
 
 export async function api(method: string, path: string, body?: unknown): Promise<any> {
   const opts: RequestInit = { method };
@@ -6,5 +28,11 @@ export async function api(method: string, path: string, body?: unknown): Promise
     opts.headers = { 'Content-Type': 'application/json' };
     opts.body = JSON.stringify(body);
   }
-  return (await fetch(`${API}${path}`, opts)).json();
+  return (await fetch(apiUrl(path), opts)).json();
+}
+
+function normalizeApiBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (trimmed.endsWith(API_PATH)) return trimmed.slice(0, -API_PATH.length);
+  return trimmed;
 }

--- a/frontend/src/install.ts
+++ b/frontend/src/install.ts
@@ -1,4 +1,4 @@
-import { api, API } from './api';
+import { api, apiUrl } from './api';
 import { showError, errMessage } from './utils';
 import { startLoaderInstall, connectLoaderInstallSSE } from './loaders/api';
 import { createProgressEstimator } from './progress-estimation';
@@ -340,7 +340,7 @@ async function connectVanillaEvents(installId: string, versionId: string): Promi
     return;
   }
 
-  const es = new EventSource(`${API}/install/${installId}/events`);
+  const es = new EventSource(apiUrl(`/install/${installId}/events`));
   setInstallEventSource(es);
 
   es.addEventListener('progress', (e: MessageEvent) => {

--- a/frontend/src/launch.ts
+++ b/frontend/src/launch.ts
@@ -1,4 +1,4 @@
-import { api, API } from './api';
+import { api, apiUrl } from './api';
 import { byId } from './dom';
 import { Sound } from './sound';
 import { Music } from './music';
@@ -512,7 +512,7 @@ async function connectLaunchEvents(sessionId: string, instanceId: string, instan
     return;
   }
 
-  const es = new EventSource(`${API}/launch/${sessionId}/events`);
+  const es = new EventSource(apiUrl(`/launch/${sessionId}/events`));
   es.addEventListener('status', (e: MessageEvent) => {
     onStatus(JSON.parse(e.data), es);
   });

--- a/frontend/src/loaders/api.ts
+++ b/frontend/src/loaders/api.ts
@@ -1,4 +1,4 @@
-import { api, API } from '../api';
+import { api, apiUrl } from '../api';
 import type {
   LoaderBuildRecord,
   LoaderBuildsResponse,
@@ -118,7 +118,7 @@ export function connectLoaderInstallSSE(
   onDone: () => void,
   onError: (message: string) => void,
 ): EventSource {
-  const es = new EventSource(`${API}/loaders/install/${installId}/events`);
+  const es = new EventSource(apiUrl(`/loaders/install/${installId}/events`));
 
   es.addEventListener('progress', (e: MessageEvent) => {
     const data = JSON.parse(e.data);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@ import {
   appVersion, bootstrapError, bootstrapState, config, instances, lastInstanceId,
   systemInfo, versions, devMode,
 } from './store';
-import { api } from './api';
+import { api, initializeApiBase } from './api';
 import { applyTheme } from './theme';
 import { Sound, bindButtonSounds } from './sound';
 import { Music } from './music';
@@ -30,6 +30,8 @@ async function init(): Promise<void> {
   bindButtonSounds();
 
   try {
+    await initializeApiBase();
+
     const nativeVersion = await getNativeAppVersion();
     if (nativeVersion) appVersion.value = nativeVersion;
 

--- a/frontend/src/music.ts
+++ b/frontend/src/music.ts
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals';
-import { api, API } from './api';
+import { api, apiUrl } from './api';
 import { byId } from './dom';
 
 const DEFAULT_TRACK_COUNT = 2;
@@ -133,7 +133,7 @@ export const Music = {
       audio.preload = 'none';
     }
     if (!this.ready) {
-      audio.src = `${API}/music/track?t=${this.track}`;
+      audio.src = apiUrl(`/music/track?t=${this.track}`);
       this.ready = true;
     }
     if (!audio.paused) return;
@@ -157,7 +157,7 @@ export const Music = {
     if (audio && !audio.paused) {
       startFade(0, () => {
         audio!.pause();
-        audio!.src = `${API}/music/track?t=${this.track}`;
+        audio!.src = apiUrl(`/music/track?t=${this.track}`);
         this.ready = true;
         this.play();
       });

--- a/frontend/src/native.ts
+++ b/frontend/src/native.ts
@@ -77,6 +77,12 @@ export async function getNativeAppVersion(): Promise<string | null> {
   return tauri.core.invoke<string>('app_version');
 }
 
+export async function getNativeApiBaseUrl(): Promise<string | null> {
+  const tauri = getTauriBinding();
+  if (!tauri?.core) return null;
+  return tauri.core.invoke<string>('api_base_url');
+}
+
 export async function browseDirectory(defaultPath = ''): Promise<string | null> {
   const tauri = getTauriBinding();
   if (!tauri?.dialog) return null;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Standardize Tauri desktop runtime topology with ephemeral API port and CORS layer
- Desktop shell now binds its Axum API to an OS-assigned ephemeral loopback port and exposes the address to the frontend via a `api_base_url` Tauri command; the frontend calls `initializeApiBase()` at startup to resolve the correct URL.
- A CORS layer is added to the API router, permitting requests only from `tauri://localhost`, `tauri.localhost`, and numeric-port localhost origins.
- The frontend dev server is pinned to port 3000 via a new `--strict-port` flag and `dev:desktop` script; the `dev` shell script starts and health-checks the dev server before launching the Tauri process.
- All tooling (CI, release, Taskfile, `dev` script) drops `corepack pnpm` in favor of direct `pnpm` invocations.
- Behavioral Change: desktop capability remote URL allowlist changes from port 43430 to 3000; standalone browser dev still targets port 43430 for the API by default.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fa8487.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->