### PR TITLE
[desktop] use native window chrome per platform

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -2,6 +2,8 @@ use serde_json::Value;
 use std::{env, fs};
 
 const DEV_TAURI_CONFIG: &str = "tauri.dev.conf.json";
+const MACOS_TAURI_CONFIG: &str = "tauri.macos.conf.json";
+const WINDOWS_TAURI_CONFIG: &str = "tauri.windows.conf.json";
 const DEV_ICON_ICNS: &str = "icons/dev/macos/icon.icns";
 const DEV_ICON_PNG: &str = "icons/dev/icon.png";
 const DEV_ICON_ICO: &str = "icons/dev/icon.ico";
@@ -20,6 +22,8 @@ fn apply_dev_tauri_config() {
     }
 
     println!("cargo:rerun-if-changed={DEV_TAURI_CONFIG}");
+    println!("cargo:rerun-if-changed={MACOS_TAURI_CONFIG}");
+    println!("cargo:rerun-if-changed={WINDOWS_TAURI_CONFIG}");
     println!("cargo:rerun-if-changed={DEV_ICON_ICNS}");
     println!("cargo:rerun-if-changed={DEV_ICON_PNG}");
     println!("cargo:rerun-if-changed={DEV_ICON_ICO}");

--- a/apps/desktop/src/commands/mod.rs
+++ b/apps/desktop/src/commands/mod.rs
@@ -37,9 +37,38 @@ pub struct NativeMicrosoftSignIn {
     owns_minecraft_java: Option<bool>,
 }
 
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct NativeDesktopChrome {
+    platform: &'static str,
+    chrome_mode: &'static str,
+}
+
 #[tauri::command]
 pub fn app_version(state: State<'_, DesktopState>) -> String {
     state.version().to_string()
+}
+
+#[tauri::command]
+pub fn desktop_chrome() -> NativeDesktopChrome {
+    NativeDesktopChrome {
+        platform: std::env::consts::OS,
+        chrome_mode: desktop_chrome_mode(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn desktop_chrome_mode() -> &'static str {
+    "mac-overlay"
+}
+
+#[cfg(target_os = "windows")]
+fn desktop_chrome_mode() -> &'static str {
+    "custom-frameless"
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn desktop_chrome_mode() -> &'static str {
+    "native-decorated"
 }
 
 #[tauri::command]

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -83,6 +83,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
             commands::app_version,
             commands::app_restart,
             commands::api_base_url,
+            commands::desktop_chrome,
             commands::microsoft_sign_in,
             commands::read_skin_file,
             commands::start_install_events,

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -17,8 +17,9 @@
         "height": 720,
         "minWidth": 960,
         "minHeight": 640,
-        "decorations": false,
+        "decorations": true,
         "transparent": false,
+        "shadow": true,
         "backgroundColor": "#100D0AFF"
       }
     ],

--- a/apps/desktop/tauri.macos.conf.json
+++ b/apps/desktop/tauri.macos.conf.json
@@ -1,0 +1,24 @@
+{
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Croopor",
+        "width": 1100,
+        "height": 720,
+        "minWidth": 960,
+        "minHeight": 640,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": {
+          "x": 16,
+          "y": 19
+        },
+        "hiddenTitle": true,
+        "transparent": false,
+        "shadow": true,
+        "backgroundColor": "#100D0AFF"
+      }
+    ]
+  }
+}

--- a/apps/desktop/tauri.windows.conf.json
+++ b/apps/desktop/tauri.windows.conf.json
@@ -1,0 +1,18 @@
+{
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Croopor",
+        "width": 1100,
+        "height": 720,
+        "minWidth": 960,
+        "minHeight": 640,
+        "decorations": false,
+        "transparent": false,
+        "shadow": true,
+        "backgroundColor": "#100D0AFF"
+      }
+    ]
+  }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -36,6 +36,7 @@ This project is a desktop Minecraft launcher, not a marketing site. Keep UI work
 ## Shell
 - The sidebar is a fixed 68px icon rail (`.cp-rail`): brand, search, Home/Instances/New, instance identity tiles, settings, player head. There is no expanded sidebar mode; labels live in tooltips and the command palette.
 - Active instance tile: full-color tile plus raised shadow while siblings sit dimmed. Do not use rings or borders because they clip in the scroll container. Running instances get a status dot. Keep rail items 44px.
+- Desktop window chrome is platform-owned where possible: Linux uses the base native-decorated Tauri window, macOS uses native decorations with the overlay traffic-light titlebar, and Windows keeps the custom frameless shell. The frontend consumes the shell-authored chrome mode from Tauri instead of sniffing browser user agents. Keep duplicated `app.windows` blocks in platform-specific Tauri configs in sync because platform config arrays replace the base array.
 
 ## Selection & Active States
 - One selection language everywhere: solid `--accent-fill` background with `--accent-on` content (the onboarding pill pattern). No translucent accent washes, no accent borders for selection. Applies to rail nav, version rows, source tiles, runtime presets, icon-button active, settings rail, on/off pills.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -19,6 +19,7 @@ import { applyTheme } from './theme';
 import { Sound, bindButtonSounds } from './sound';
 import { Music } from './music';
 import {
+  applyDesktopChromeAttributes,
   getNativeAppVersion,
   hasNativeDesktopRuntime,
   nativeDesktopCloseBlockedEventName,
@@ -34,6 +35,7 @@ import { restoreRoute, showOnboardingOverlay } from './ui-state';
 
 async function init(): Promise<void> {
   initErrorReporting();
+  await applyDesktopChromeAttributes();
 
   // Theme before anything else so the first paint is tinted correctly
   applyTheme(local.theme, local.customHue, {

--- a/frontend/src/native.ts
+++ b/frontend/src/native.ts
@@ -55,6 +55,66 @@ export function hasNativeDesktopRuntime(): boolean {
   return isTauriRuntime();
 }
 
+export type DesktopPlatform = 'browser' | 'linux' | 'macos' | 'unknown' | 'windows';
+export type DesktopChromeMode = 'browser' | 'custom-frameless' | 'mac-overlay' | 'native-decorated';
+
+export interface NativeDesktopChrome {
+  platform: DesktopPlatform;
+  chrome_mode: DesktopChromeMode;
+}
+
+const browserDesktopChrome: NativeDesktopChrome = {
+  platform: 'browser',
+  chrome_mode: 'browser',
+};
+
+let desktopChrome = browserDesktopChrome;
+
+function desktopPlatformFromPayload(value: unknown): DesktopPlatform {
+  return value === 'linux' || value === 'macos' || value === 'windows' ? value : 'unknown';
+}
+
+function desktopChromeModeFromPayload(value: unknown): DesktopChromeMode {
+  return value === 'custom-frameless' || value === 'mac-overlay' || value === 'native-decorated' ? value : 'browser';
+}
+
+function desktopChromeFromPayload(payload: unknown): NativeDesktopChrome {
+  if (!payload || typeof payload !== 'object') return browserDesktopChrome;
+  const record = payload as { platform?: unknown; chrome_mode?: unknown };
+  return {
+    platform: desktopPlatformFromPayload(record.platform),
+    chrome_mode: desktopChromeModeFromPayload(record.chrome_mode),
+  };
+}
+
+async function getNativeDesktopChrome(): Promise<NativeDesktopChrome> {
+  const tauri = getTauriBinding();
+  if (!tauri?.core) return browserDesktopChrome;
+  const payload = await tauri.core.invoke<unknown>('desktop_chrome');
+  return desktopChromeFromPayload(payload);
+}
+
+export function currentDesktopChrome(): NativeDesktopChrome {
+  return desktopChrome;
+}
+
+export function hasCustomWindowControls(): boolean {
+  return desktopChrome.chrome_mode === 'custom-frameless';
+}
+
+export function hasCustomDragRegion(): boolean {
+  return desktopChrome.chrome_mode === 'custom-frameless' || desktopChrome.chrome_mode === 'mac-overlay';
+}
+
+export async function applyDesktopChromeAttributes(): Promise<void> {
+  desktopChrome = await getNativeDesktopChrome().catch(() => browserDesktopChrome);
+  const root = document.documentElement;
+  root.dataset.desktopPlatform = desktopChrome.platform;
+  root.dataset.desktopChrome = desktopChrome.chrome_mode;
+  root.dataset.windowControls = hasCustomWindowControls() ? 'custom' : 'native';
+  root.dataset.windowFrame = desktopChrome.chrome_mode;
+}
+
 export function nativeInstallEventName(installId: string): string {
   return `croopor:install:${installId}:progress`;
 }

--- a/frontend/src/shell/BootSplash.tsx
+++ b/frontend/src/shell/BootSplash.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { bootstrapError, bootstrapState } from '../store';
-import { hasNativeDesktopRuntime, windowStartDragging } from '../native';
+import { hasCustomDragRegion, windowStartDragging } from '../native';
 import { Logo } from '../ui/Logo';
 
 const MIN_DISPLAY_MS = 500;
@@ -39,7 +39,7 @@ export function BootSplash(): JSX.Element | null {
   const [leaving, setLeaving] = useState(false);
   const [gone, setGone] = useState(false);
   const mountedAt = useRef(Date.now());
-  const isNative = useRef(hasNativeDesktopRuntime());
+  const usesCustomDrag = useRef(hasCustomDragRegion());
 
   useEffect(() => {
     if (state !== 'loading') return;
@@ -66,7 +66,7 @@ export function BootSplash(): JSX.Element | null {
   if (gone) return null;
 
   const onMouseDown = (e: MouseEvent): void => {
-    if (!isNative.current || e.button !== 0) return;
+    if (!usesCustomDrag.current || e.button !== 0) return;
     void windowStartDragging();
   };
 

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -361,8 +361,8 @@ export function Sidebar(): JSX.Element {
 
   return (
     <aside class="cp-rail" ref={railRef}>
-      <div class="cp-rail-brand" {...railTipAttrs('Croopor', tooltip)}>
-        <Logo className="cp-logo" motion="loose" size={34} />
+      <div class="cp-rail-brand" aria-hidden="true">
+        <Logo className="cp-logo" size={34} />
       </div>
       <button
         class="cp-rail-btn"

--- a/frontend/src/shell/Topbar.tsx
+++ b/frontend/src/shell/Topbar.tsx
@@ -8,7 +8,7 @@ import { goBack, goForward, navigate, route } from '../ui-state';
 import { runningSessions, instances, versionById, launchState } from '../store';
 import { activeDownload, downloadFailure, downloadQueue } from '../machines/downloads';
 import { minecraftVersionLabel } from '../version-display';
-import { windowStartDragging, windowToggleMaximize, hasNativeDesktopRuntime } from '../native';
+import { hasCustomDragRegion, windowStartDragging, windowToggleMaximize } from '../native';
 
 function assertUnreachable(value: never): never {
   throw new Error(`Unhandled route: ${JSON.stringify(value)}`);
@@ -161,16 +161,16 @@ function StatusPill(): JSX.Element {
 }
 
 export function Topbar(): JSX.Element {
-  const [isNative] = useState(hasNativeDesktopRuntime());
+  const [usesCustomDrag] = useState(hasCustomDragRegion());
 
   const onDragAreaDoubleClick = (e: MouseEvent): void => {
-    if (!isNative) return;
+    if (!usesCustomDrag) return;
     if ((e.target as HTMLElement)?.closest('.cp-nodrag')) return;
     void windowToggleMaximize();
   };
 
   const onDragAreaMouseDown = (e: MouseEvent): void => {
-    if (!isNative) return;
+    if (!usesCustomDrag) return;
     if ((e.target as HTMLElement)?.closest('.cp-nodrag')) return;
     if (e.button !== 0) return;
     void windowStartDragging();
@@ -178,7 +178,11 @@ export function Topbar(): JSX.Element {
 
   const crumbs = crumbsFor();
   return (
-    <div class="cp-topbar cp-drag" onMouseDown={onDragAreaMouseDown} onDblClick={onDragAreaDoubleClick}>
+    <div
+      class={`cp-topbar${usesCustomDrag ? ' cp-drag' : ''}`}
+      onMouseDown={onDragAreaMouseDown}
+      onDblClick={onDragAreaDoubleClick}
+    >
       <div class="cp-nodrag" style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
         <IconButton icon="arrow-left" size={28} tooltip="Back" onClick={goBack} />
         <IconButton icon="arrow-right" size={28} tooltip="Forward" onClick={goForward} />

--- a/frontend/src/shell/WindowControls.tsx
+++ b/frontend/src/shell/WindowControls.tsx
@@ -9,23 +9,25 @@ import {
   windowMinimize,
   windowToggleMaximize,
   windowIsMaximized,
+  hasCustomWindowControls,
 } from '../native';
 
 export function WindowControls(): JSX.Element | null {
   const isNative = hasNativeDesktopRuntime();
+  const hasCustomControls = hasCustomWindowControls();
   const [maximized, setMaximized] = useState(false);
 
   useEffect(() => {
-    if (!isNative) return;
+    if (!isNative || !hasCustomControls) return;
     const syncMaximized = (): void => {
       void windowIsMaximized().then(setMaximized);
     };
     syncMaximized();
     window.addEventListener('focus', syncMaximized);
     return () => window.removeEventListener('focus', syncMaximized);
-  }, [isNative]);
+  }, [hasCustomControls, isNative]);
 
-  if (!isNative) return null;
+  if (!isNative || !hasCustomControls) return null;
 
   const onMin = (): void => {
     void windowMinimize();

--- a/frontend/src/shell/shell.css
+++ b/frontend/src/shell/shell.css
@@ -1,3 +1,13 @@
+:root {
+  --cp-window-titlebar-safe-h: 0px;
+  --cp-window-onboarding-strip-h: 36px;
+}
+
+html[data-desktop-chrome='mac-overlay'] {
+  --cp-window-titlebar-safe-h: 38px;
+  --cp-window-onboarding-strip-h: 40px;
+}
+
 .cp-frame {
   --cp-topbar-h: 46px;
   width: 100%;
@@ -18,7 +28,7 @@
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  padding: 10px 0 12px;
+  padding: calc(10px + var(--cp-window-titlebar-safe-h)) 0 12px;
   background: transparent;
 }
 .cp-rail-brand {
@@ -28,11 +38,15 @@
   align-items: center;
   justify-content: center;
   margin-bottom: 2px;
+  pointer-events: none;
 }
 .cp-logo {
   width: 34px;
   height: 34px;
   display: block;
+}
+html[data-desktop-chrome='mac-overlay'] .cp-rail-brand {
+  display: none;
 }
 .cp-mark {
   overflow: visible;

--- a/frontend/src/views/onboarding/onboarding.css
+++ b/frontend/src/views/onboarding/onboarding.css
@@ -128,11 +128,16 @@
 
 .cp-ob-topstrip {
   flex-shrink: 0;
-  height: 36px;
+  height: var(--cp-window-onboarding-strip-h, 36px);
   display: flex;
   align-items: stretch;
   justify-content: flex-end;
   padding-right: 2px;
+}
+
+html[data-desktop-chrome='browser'] .cp-ob-topstrip,
+html[data-desktop-chrome='native-decorated'] .cp-ob-topstrip {
+  display: none;
 }
 
 .cp-ob-column {


### PR DESCRIPTION
## Summary
- use platform-specific Tauri window configs for macOS, Windows, and the native-decorated default
- expose the desktop chrome mode from Tauri and gate frontend drag/window-control behavior from that contract
- adjust the macOS shell spacing/logo treatment and document the chrome model

## Verification
- pnpm --dir frontend run build
- cargo check --locked -p croopor-desktop
- cargo fmt --all
- Prettier on touched frontend files
- git diff --check

## Notes
- Three-OS visual smoke is still the merge gate: Linux native titlebar/no custom controls, macOS overlay traffic lights/no overlap, Windows frameless/custom controls and drag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved desktop window styling across macOS, Windows, and Linux, with platform-appropriate title bar and window controls.
  * Added startup detection so the app can adapt its layout and interactions to the current desktop chrome.

* **Bug Fixes**
  * Fixed drag, maximize, and window control behavior so they only appear when supported.
  * Adjusted spacing and onboarding layout to prevent overlap with platform-specific window chrome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use native window chrome per platform in the desktop shell
> - Adds a `desktop_chrome` Tauri command that returns the current platform and chrome mode (`mac-overlay`, `custom-frameless`, or `native-decorated`) based on compile-time target OS.
> - At startup, the frontend invokes this command and writes `data-desktop-platform`, `data-desktop-chrome`, `data-window-controls`, and `data-window-frame` attributes to `document.documentElement`, allowing CSS and components to adapt per platform.
> - macOS uses an overlay titlebar (hidden title, custom traffic light position); Windows uses a frameless window with custom controls; all other platforms use native OS decorations.
> - Custom window controls and drag regions are now gated on `hasCustomWindowControls()` and `hasCustomDragRegion()` helpers, replacing the previous `hasNativeDesktopRuntime()` checks in `Topbar`, `BootSplash`, and `WindowControls`.
> - The onboarding top strip and sidebar brand mark are hidden on `native-decorated` and `browser` chrome modes; macOS overlay gets extra top padding via a CSS custom property.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d04c98d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->